### PR TITLE
Fix for missing undated rbc bank stmt rows

### DIFF
--- a/pdf2txt.py
+++ b/pdf2txt.py
@@ -115,6 +115,7 @@ def roll_up_rbc_bank_transactions(text_lines: List[str]) -> List[str]:
     roll_up = ""
     in_rollup = False
     in_balance = False
+    in_date = False
     field_number = 0
     initial_balance = 0.0
     current_balance = 0.0
@@ -131,17 +132,20 @@ def roll_up_rbc_bank_transactions(text_lines: List[str]) -> List[str]:
         if text_line == "Opening Balance":
             in_balance = True
             in_rollup = False
+            in_date = False
         elif in_balance:
             initial_balance = float(text_line.replace(",", "").replace("$", ""))
             in_balance = False
+            in_date = False
         elif utils.is_dd_mon_date(text_line):
             in_rollup = True
             in_balance = False
+            in_date = True
             field_number = 0
             roll_up = ""
             days_entries = []
             current_date = f"{text_line} {year}"
-        elif in_rollup:
+        elif in_rollup or in_date:
             field_number += 1
             if field_number == 1:
                 roll_up = f"{current_date}\t{text_line}"


### PR DESCRIPTION
## Summary
### Issue
RBC Bank transactions which occur on the same day are left undated. The `pdf2txt.py` script does not take these rows into account, as it checks if a row is dated before parsing the transaction info.

For example, here is a sample of an RBC bank statement
```
Date          Description         Withdrawals ($)       Deposits ($)        Balance ($)
------------------------------------------------------------------------------------------------------------
                 Opening Balance                                                                1,000.00
------------------------------------------------------------------------------------------------------------
Apr 18      Transaction 1      100.0                                                      900.00 
------------------------------------------------------------------------------------------------------------
                  Transaction 2                                          500.00                1,400.00
------------------------------------------------------------------------------------------------------------
                  Transaction 3      100                                                         1,300.00
------------------------------------------------------------------------------------------------------------
Apr 19      Transaction4                                           200.00                1,500.00    
------------------------------------------------------------------------------------------------------------                                 
```
Prior to the fix `pdf2txt.py`  will skip over `Transaction 2` & `Transaction 3` 

### Solution
Added a 3rd state to the "roll up" loop, which tracks if the current row is one of these undated transactions

